### PR TITLE
Move annotations to the correct position in a class

### DIFF
--- a/BioChem/Compartments/Compartment.mo
+++ b/BioChem/Compartments/Compartment.mo
@@ -1,13 +1,13 @@
 within BioChem.Compartments;
 
 model Compartment "Default compartment (constant volume)"
+  extends BioChem.Interfaces.Compartments.Compartment(V(stateSelect=StateSelect.prefer));
+equation
+  der(V)=0 "Compartment volume is constant";
   annotation(Documentation(info="<html>
 <h1>Compartment</h1>
 <p>
 Default compartment model.
 </p>
 </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Text(fillColor={0,85,0}, fillPattern=FillPattern.Solid, extent={{-100,-170},{100,-120}}, textString="%name", fontName="Arial"),Rectangle(lineColor={0,85,0}, fillColor={199,199,149}, fillPattern=FillPattern.Solid, lineThickness=10, extent={{-110,-110},{110,110}}, radius=20)}), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-  extends BioChem.Interfaces.Compartments.Compartment(V(stateSelect=StateSelect.prefer));
-equation
-  der(V)=0 "Compartment volume is constant";
 end Compartment;

--- a/BioChem/Interfaces/Reactions/Basics/FourSubstrates.mo
+++ b/BioChem/Interfaces/Reactions/Basics/FourSubstrates.mo
@@ -1,9 +1,9 @@
 within BioChem.Interfaces.Reactions.Basics;
 
 model FourSubstrates
-  annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Line(points={{-100,87.5},{-62.5,87.5},{-50,0}}, color={170,0,0}, smooth=Smooth.Bezier),Line(points={{-100,-87.5},{-62.5,-87.5},{-50,0}}, color={170,0,0}, smooth=Smooth.Bezier),Line(points={{-100,-37.5},{-62.5,-37.5},{-50,0}}, color={170,0,0}, smooth=Smooth.Bezier),Line(points={{-100,37.5},{-62.5,37.5},{-50,0}}, color={170,0,0}, smooth=Smooth.Bezier)}), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   BioChem.Interfaces.Nodes.SubstrateConnector s4 annotation(Placement(transformation(origin={-90,-87.5}, extent={{-10,-10},{10,10}}), iconTransformation(origin={-112.5,-87.5}, extent={{-12.5,-12.5},{12.5,12.5}})));
   BioChem.Interfaces.Nodes.SubstrateConnector s2 annotation(Placement(transformation(origin={-90,-35}, extent={{-10,-10},{10,10}}), iconTransformation(origin={-112.5,-37.5}, extent={{-12.5,-12.5},{12.5,12.5}})));
   BioChem.Interfaces.Nodes.SubstrateConnector s3 annotation(Placement(transformation(origin={-90,25}, extent={{-10,-10},{10,10}}), iconTransformation(origin={-112.5,37.5}, extent={{-12.5,-12.5},{12.5,12.5}})));
   BioChem.Interfaces.Nodes.SubstrateConnector s1 annotation(Placement(transformation(origin={-87.5,87.5}, extent={{-10,-10},{10,10}}), iconTransformation(origin={-112.5,87.5}, extent={{-12.5,-12.5},{12.5,12.5}})));
+  annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Line(points={{-100,87.5},{-62.5,87.5},{-50,0}}, color={170,0,0}, smooth=Smooth.Bezier),Line(points={{-100,-87.5},{-62.5,-87.5},{-50,0}}, color={170,0,0}, smooth=Smooth.Bezier),Line(points={{-100,-37.5},{-62.5,-37.5},{-50,0}}, color={170,0,0}, smooth=Smooth.Bezier),Line(points={{-100,37.5},{-62.5,37.5},{-50,0}}, color={170,0,0}, smooth=Smooth.Bezier)}), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end FourSubstrates;

--- a/BioChem/Interfaces/Reactions/Basics/OneSubstrate.mo
+++ b/BioChem/Interfaces/Reactions/Basics/OneSubstrate.mo
@@ -1,6 +1,6 @@
 within BioChem.Interfaces.Reactions.Basics;
 
 partial model OneSubstrate "SubstanceConnector for one substrate"
-  annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Line(points={{-50,0},{-100,0}}, color={170,0,0}, arrowSize=25)}), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   BioChem.Interfaces.Nodes.SubstrateConnector s1 annotation(Placement(transformation(origin={-80,0}, extent={{-10,-10},{10,10}}), iconTransformation(origin={-112.5,-2.22045e-16}, extent={{-12.5,-12.5},{12.5,12.5}})));
+  annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Line(points={{-50,0},{-100,0}}, color={170,0,0}, arrowSize=25)}), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end OneSubstrate;

--- a/BioChem/Interfaces/Reactions/Modifiers/ModifierForward.mo
+++ b/BioChem/Interfaces/Reactions/Modifiers/ModifierForward.mo
@@ -1,8 +1,8 @@
 within BioChem.Interfaces.Reactions.Modifiers;
 
 partial model ModifierForward "Basics for a forward modifier in a reaction edge"
-  annotation(Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Line(points={{0,56.25},{0,6.25}}, color={0,0,255}, arrow={Arrow.None,Arrow.Open}, arrowSize=25)}));
   BioChem.Interfaces.Nodes.ModifierConnector mF1 annotation(Placement(transformation(origin={1.11022e-16,90}, extent={{-10,-10},{10,10}}), iconTransformation(origin={-1.5099e-14,90}, extent={{-20,-20},{20,20}})));
 equation
   mF1.r=0;
+  annotation(Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Line(points={{0,56.25},{0,6.25}}, color={0,0,255}, arrow={Arrow.None,Arrow.Open}, arrowSize=25)}));
 end ModifierForward;

--- a/BioChem/Interfaces/Reactions/Uui.mo
+++ b/BioChem/Interfaces/Reactions/Uui.mo
@@ -6,8 +6,8 @@ partial model Uui "Uni-Uni irreversible reaction"
   extends BioChem.Interfaces.Reactions.Basics.OneProduct;
   BioChem.Units.StoichiometricCoefficient nS1=1 "Stoichiometric coefficient for the substrate";
   BioChem.Units.StoichiometricCoefficient nP1=1 "Stoichiometric coefficient for the product";
-  annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 equation
   s1.r=nS1*rr;
   p1.r=-nP1*rr;
+  annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end Uui;

--- a/BioChem/Interfaces/Reactions/Uur.mo
+++ b/BioChem/Interfaces/Reactions/Uur.mo
@@ -6,8 +6,8 @@ partial model Uur "Uni-Uni reversible reaction"
   extends BioChem.Interfaces.Reactions.Basics.OneProduct;
   BioChem.Units.StoichiometricCoefficient nS1=1 "Stoichiometric coefficient for the substrate";
   BioChem.Units.StoichiometricCoefficient nP1=1 "Stoichiometric coefficient for the product";
-  annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 equation
   s1.r=nS1*rr;
   p1.r=-nP1*rr;
+  annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end Uur;

--- a/BioChem/Reactions/Activation/package.mo
+++ b/BioChem/Reactions/Activation/package.mo
@@ -1,22 +1,7 @@
 within BioChem.Reactions;
 package Activation "Activation kinetics reactions"
   extends Icons.Library;
-  annotation(Documentation(info="<html>
-<h1>Activation</h1>
- <p>
-This package contains models for irreversible and reversible activation reaction kinetics.
- </p>
-
-<br>
-<img src=\"modelica://BioChem/Resources/Images/Activation.png\" >
-<br>
- </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   model Umar "Reversible mixed activation kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Reversible mixed activation kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uur;
     extends BioChem.Interfaces.Reactions.Modifiers.Activator;
     parameter BioChem.Units.Concentration Kas=1 "Activation constant";
@@ -27,14 +12,14 @@ This package contains models for irreversible and reversible activation reaction
     parameter BioChem.Units.ReactionRate vR=1 "Backward maximum velocity";
   equation
     rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + Kas/a1.c + (s1.c/KmS + p1.c/KmP)*(1 + Kac/a1.c));
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible mixed activation kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Umar;
 
   model Umai "Irreversible mixed activation kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible mixed activation kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     extends BioChem.Interfaces.Reactions.Modifiers.Activator;
     parameter BioChem.Units.Concentration Kac=1 "Activation constant";
@@ -43,14 +28,14 @@ This package contains models for irreversible and reversible activation reaction
     parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
   equation
     rr=vF*s1.c*a1.c/(s1.c*(a1.c + Kac) + KmS*(a1.c + Kas));
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible mixed activation kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Umai;
 
   model Uctr "Reversible catalytic activation"
-    annotation(Documentation(info="<html>
- <p>
- Reversible catalytic activation.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uur;
     extends BioChem.Interfaces.Reactions.Modifiers.Activator;
     parameter BioChem.Units.Concentration Ka=1 "Activation constant";
@@ -60,14 +45,14 @@ This package contains models for irreversible and reversible activation reaction
     parameter BioChem.Units.ReactionRate vR=1 "Backward maximum velocity";
   equation
     rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + Ka/a1.c + (s1.c/KmS + p1.c/KmP)*(1 + Ka/a1.c));
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible catalytic activation.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uctr;
 
   model Ucti "Irreversible catalytic activation"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible catalytic activation.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     extends BioChem.Interfaces.Reactions.Modifiers.Activator;
     parameter BioChem.Units.Concentration Ka=1 "Activation constant";
@@ -75,14 +60,14 @@ This package contains models for irreversible and reversible activation reaction
     parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
   equation
     rr=vF*s1.c*a1.c/((a1.c + Ka)*(s1.c + KmS));
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible catalytic activation.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Ucti;
 
   model Uar "Reversible specific activation kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Reversible specific activation kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uur;
     extends BioChem.Interfaces.Reactions.Modifiers.Activator;
     parameter BioChem.Units.Concentration Ka=1 "Activation constant";
@@ -92,14 +77,14 @@ This package contains models for irreversible and reversible activation reaction
     parameter BioChem.Units.ReactionRate vR=1 "Backward maximum velocity";
   equation
     rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + s1.c/KmS + p1.c/KmP + Ka/a1.c);
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible specific activation kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uar;
 
   model Uaii "Irreversible specific activation kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible specific activation kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     extends BioChem.Interfaces.Reactions.Modifiers.Activator;
     parameter BioChem.Units.Concentration Ka=1 "Activation constant";
@@ -107,20 +92,35 @@ This package contains models for irreversible and reversible activation reaction
     parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
   equation
     rr=vF*s1.c*a1.c/(a1.c*(KmS + s1.c) + KmS*Ka);
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible specific activation kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uaii;
 
   model Uai "Irreversible substrate activation"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible substrate activation.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     parameter BioChem.Units.Concentration KSa=1 "Dissociation constant of substrate-activation site";
     parameter BioChem.Units.Concentration KSc=1 "Dissociation constant of substrate-active site";
     parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
   equation
     rr=vF*s1.c/KSa*s1.c/KSa/(1 + s1.c/KSc + s1.c/KSa*s1.c/KSa + s1.c/KSa);
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible substrate activation.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uai;
 
+  annotation(Documentation(info="<html>
+<h1>Activation</h1>
+ <p>
+This package contains models for irreversible and reversible activation reaction kinetics.
+ </p>
+
+<br>
+<img src=\"modelica://BioChem/Resources/Images/Activation.png\" >
+<br>
+ </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end Activation;

--- a/BioChem/Reactions/BiSubstrate/package.mo
+++ b/BioChem/Reactions/BiSubstrate/package.mo
@@ -1,22 +1,7 @@
 within BioChem.Reactions;
 package BiSubstrate "Bi-substrate reactions"
   extends Icons.Library;
-  annotation(Documentation(info="<html>
-<h1>BiSubstrate</h1>
- <p>
- This package contains models for bi-substrate reactions.
- </p>
-<br>
-<img src=\"modelica://BioChem/Resources/Images/BiSubstrate.png\" >
-<br>
-
- </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   model Ppbr "Ping pong bi-bi kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Ping pong bi-bi kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Basics.Reaction;
     extends BioChem.Interfaces.Reactions.Basics.TwoSubstratesReversible;
     extends BioChem.Interfaces.Reactions.Basics.TwoProducts;
@@ -38,14 +23,14 @@ package BiSubstrate "Bi-substrate reactions"
     p2.r=-rr;
     K1=vF/(vR*Keq)*(KmP2*p1.c*(1 + s1.c/KiS1) + p2.c*(KmP1 + p1.c));
     rr=vF*(s1.c*s2.c - p1.c*p2.c/Keq)/(s1.c*s2.c + KmS2*s1.c + KmS1*s2.c*(1 + p2.c/KiP2) + K1);
+    annotation(Documentation(info="<html>
+ <p>
+ Ping pong bi-bi kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Ppbr;
 
   model Ordubr "Ordered uni-bi kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Ordered uni-bi kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Basics.Reaction;
     extends BioChem.Interfaces.Reactions.Basics.OneSubstrateReversible;
     extends BioChem.Interfaces.Reactions.Basics.TwoProducts;
@@ -61,14 +46,14 @@ package BiSubstrate "Bi-substrate reactions"
     p1.r=-rr;
     p2.r=-rr;
     rr=vF*(s1.c - p1.c*p2.c/Keq)/(KmS1 + s1.c*(1 + p1.c/KiP1) + vF/(vR*Keq)*(KmP2*p1.c + KmP1*p2.c + p1.c*p2.c));
+    annotation(Documentation(info="<html>
+ <p>
+ Ordered uni-bi kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Ordubr;
 
   model Ordbur "Ordered bi-uni kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Ordered bi-uni kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Basics.Reaction;
     extends BioChem.Interfaces.Reactions.Basics.TwoSubstratesReversible;
     extends BioChem.Interfaces.Reactions.Basics.OneProduct;
@@ -84,14 +69,14 @@ package BiSubstrate "Bi-substrate reactions"
     s2.r=rr;
     p1.r=-rr;
     rr=vF*(s1.c*s2.c - p1.c/Keq)/(s1.c*s2.c + KmS1*s2.c + KmS2*s1.c + vF/(vR*Keq)*(KmP1 + p1.c*(1 + s1.c/KiS1)));
+    annotation(Documentation(info="<html>
+ <p>
+ Ordered bi-uni kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Ordbur;
 
   model Ordbbr "Ordered bi-bi kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Ordered bi-bi kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Basics.Reaction;
     extends BioChem.Interfaces.Reactions.Basics.TwoSubstratesReversible;
     extends BioChem.Interfaces.Reactions.Basics.TwoProducts;
@@ -116,6 +101,21 @@ package BiSubstrate "Bi-substrate reactions"
     K1=vF/(vR*Keq)*(KmP2*p1.c*(1 + s1.c/KiS1) + p2.c*K2);
     K2=KmP1*(1 + KmS1*s2.c/(KiS1*KmS2) + p1.c*(1 + s2.c/KiS2));
     rr=vF*(s1.c*s2.c - p1.c*p2.c/Keq)/(s1.c*s2.c*(1 + p1.c/KiP1) + KmS2*(s1.c + KiS1) + KmS1*s2.c + K1);
+    annotation(Documentation(info="<html>
+ <p>
+ Ordered bi-bi kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Ordbbr;
 
+  annotation(Documentation(info="<html>
+<h1>BiSubstrate</h1>
+ <p>
+ This package contains models for bi-substrate reactions.
+ </p>
+<br>
+<img src=\"modelica://BioChem/Resources/Images/BiSubstrate.png\" >
+<br>
+
+ </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end BiSubstrate;

--- a/BioChem/Reactions/FastEquilibrium/package.mo
+++ b/BioChem/Reactions/FastEquilibrium/package.mo
@@ -2,23 +2,16 @@ within BioChem.Reactions;
 
 package FastEquilibrium "Base classes for reactions with fast (instant) equilibrium"
     extends Icons.Library;
-    annotation(Diagram(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, grid={10,10})), Documentation(info="<html>
-<h1>FastEquilibrium</h1>
-The reaction in the FastEquilibrium package is used to model reactions that are very fast, and could be seen as an instant balance. These models are approximated to very fast reactions, if translated to SBML.
-<br>
-<img src=\"modelica://BioChem/Resources/Images/Fast.png\" >
-<br>
-</html>", revisions=""));
     model Uuf "Uni-Uni fast (instant) equilibrium reaction"
       extends BioChem.Interfaces.Reactions.Basics.FastEquilibrium;
       extends BioChem.Interfaces.Reactions.Basics.OneSubstrateReversible;
       extends BioChem.Interfaces.Reactions.Basics.OneProduct;
       parameter BioChem.Units.EquilibriumCoefficient kS1=1 "Equilibrium coefficient for the substrate";
       parameter BioChem.Units.EquilibriumCoefficient kP1=1 "Equilibrium coefficient for the product";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       s1.r + p1.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Uuf;
 
     model Utf "Uni-Tri fast (instant) equilibrium reaction"
@@ -29,12 +22,12 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kP1=1 "Equilibrium coefficient for product 1";
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
       parameter BioChem.Units.EquilibriumCoefficient kP3=1 "Equilibrium coefficient for product 3";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
       p3.c=s1.c*kP3/kS1;
       s1.r + p1.r + p2.r + p3.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Utf;
 
     model Ubf "Uni-Bi fast (instant) equilibrium reaction"
@@ -44,11 +37,11 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kS1=1 "Equilibrium coefficient for the substrate";
       parameter BioChem.Units.EquilibriumCoefficient kP1=1 "Equilibrium coefficient for product 1";
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
       s1.r + p1.r + p2.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Ubf;
 
     model Ttf "Tri-Tri fast (instant) equilibrium reaction"
@@ -61,7 +54,6 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kP1=1 "Equilibrium coefficient for product 1";
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
       parameter BioChem.Units.EquilibriumCoefficient kP3=1 "Equilibrium coefficient for product 3";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
@@ -69,6 +61,7 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       s2.c=s1.c*kS2/kS1;
       s3.c=s1.c*kS3/kS1;
       s1.r + s2.r + s3.r + p1.r + p2.r + p3.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Ttf;
 
     model Btf "Bi-Tri fast (instant) equilibrium reaction"
@@ -80,13 +73,13 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kP1=1 "Equilibrium coefficient for product 1";
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
       parameter BioChem.Units.EquilibriumCoefficient kP3=1 "Equilibrium coefficient for product 3";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
       p3.c=s1.c*kP3/kS1;
       s2.c=s1.c*kS2/kS1;
       s1.r + s2.r + p1.r + p2.r + p3.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Btf;
 
     model Bbf "Bi-Bi fast (instant) equilibrium reaction"
@@ -97,12 +90,12 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kS2=1 "Equilibrium coefficient for substrate 2";
       parameter BioChem.Units.EquilibriumCoefficient kP1=1 "Equilibrium coefficient for product 1";
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
       s2.c=s1.c*kS2/kS1;
       s1.r + s2.r + p1.r + p2.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Bbf;
 
     model Qqf "Quad-Quad fast (instant) equilibrium reaction"
@@ -117,7 +110,6 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
       parameter BioChem.Units.EquilibriumCoefficient kP3=1 "Equilibrium coefficient for product 3";
       parameter BioChem.Units.EquilibriumCoefficient kP4=1 "Equilibrium coefficient for product 4";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
@@ -127,6 +119,7 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       s3.c=s1.c*kS3/kS1;
       s4.c=s1.c*kS4/kS1;
       s1.r + s2.r + s3.r + s4.r + p1.r + p2.r + p3.r + p4.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Qqf;
 
     model Uqf
@@ -138,13 +131,13 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
       parameter BioChem.Units.EquilibriumCoefficient kP3=1 "Equilibrium coefficient for product 3";
       parameter BioChem.Units.EquilibriumCoefficient kP4=1 "Equilibrium coefficient for product 4";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
       p3.c=s1.c*kP3/kS1;
       p4.c=s1.c*kP4/kS1;
       s1.r + p1.r + p2.r + p3.r + p4.c=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Uqf;
 
     model Bqf "Bi-Quad fast (instant) equilibrium reaction"
@@ -157,7 +150,6 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
       parameter BioChem.Units.EquilibriumCoefficient kP3=1 "Equilibrium coefficient for product 3";
       parameter BioChem.Units.EquilibriumCoefficient kP4=1 "Equilibrium coefficient for product 4";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
@@ -165,6 +157,7 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       p4.c=s1.c*kP4/kS1;
       s2.c=s1.c*kS2/kS1;
       s1.r + s2.r + p1.r + p2.r + p3.r + p4.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Bqf;
 
     model Tqf "Tri-Quad fast (instant) equilibrium reaction"
@@ -178,7 +171,6 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kP2=1 "Equilibrium coefficient for product 2";
       parameter BioChem.Units.EquilibriumCoefficient kP3=1 "Equilibrium coefficient for product 3";
       parameter BioChem.Units.EquilibriumCoefficient kP4=1 "Equilibrium coefficient for product 4";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       p1.c=s1.c*kP1/kS1;
       p2.c=s1.c*kP2/kS1;
@@ -187,6 +179,7 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       s2.c=s1.c*kS2/kS1;
       s3.c=s1.c*kS3/kS1;
       s1.r + s2.r + s3.r + p1.r + p2.r + p3.r + p4.r=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Tqf;
 
     model Mmf "Multi-Multi fast (instant) equilibrium reaction"
@@ -195,7 +188,6 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       extends BioChem.Interfaces.Reactions.Basics.MultipleProducts;
       parameter BioChem.Units.EquilibriumCoefficient kS[dimS]=fill(1, dimS) "Equilibrium coefficients for the substrates";
       parameter BioChem.Units.EquilibriumCoefficient kP[dimP]=fill(1, dimP) "Equilibrium coefficients for the products";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       for i in 1:dimP loop
         p[i].c=s[1].c*kP[i]/kS[1];
@@ -204,6 +196,7 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
         s[i].c=s[1].c*kS[i]/kS[1];
       end for;
       sum(s.r) + sum(p.r)=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Mmf;
 
     model Umf "Uni-Multi fast (instant) equilibrium reaction"
@@ -212,12 +205,12 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       extends BioChem.Interfaces.Reactions.Basics.MultipleProducts;
       parameter BioChem.Units.EquilibriumCoefficient kS1=1 "Equilibrium coefficient for substrate 1";
       parameter BioChem.Units.EquilibriumCoefficient kP[dimP]=fill(1, dimP) "Equilibrium coefficients for the products";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       for i in 1:dimP loop
         p[i].c=s1.c*kP[i]/kS1;
       end for;
       s1.r + sum(p.r)=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Umf;
 
     model Bmf "Bi-Multi fast (instant) equilibrium reaction"
@@ -227,13 +220,13 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kS1=1 "Equilibrium coefficient for substrate 1";
       parameter BioChem.Units.EquilibriumCoefficient kS2=1 "Equilibrium coefficient for substrate 2";
       parameter BioChem.Units.EquilibriumCoefficient kP[dimP]=fill(1, dimP) "Equilibrium coefficients for the products";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       for i in 1:dimP loop
         p[i].c=s1.c*kP[i]/kS1;
       end for;
       s2.c=s1.c*kS2/kS1;
       s1.r + s2.r + sum(p.r)=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Bmf;
 
     model Qmf "Quad-Multi fast (instant) equilibrium reaction"
@@ -245,7 +238,6 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kS3=1 "Equilibrium coefficient for substrate 3";
       parameter BioChem.Units.EquilibriumCoefficient kS4=1 "Equilibrium coefficient for substrate 4";
       parameter BioChem.Units.EquilibriumCoefficient kP[dimP]=fill(1, dimP) "Equilibrium coefficients for the products";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       for i in 1:dimP loop
         p[i].c=s1.c*kP[i]/kS1;
@@ -254,6 +246,7 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       s3.c=s1.c*kS3/kS1;
       s4.c=s1.c*kS4/kS1;
       s1.r + s2.r + s3.r + s4.r + sum(p.r)=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Qmf;
 
     model Tmf "Tri-Multi fast (instant) equilibrium reaction"
@@ -264,7 +257,6 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       parameter BioChem.Units.EquilibriumCoefficient kS2=1 "Equilibrium coefficient for substrate 2";
       parameter BioChem.Units.EquilibriumCoefficient kS3=1 "Equilibrium coefficient for substrate 3";
       parameter BioChem.Units.EquilibriumCoefficient kP[dimP]=fill(1, dimP) "Equilibrium coefficients for the products";
-      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     equation
       for i in 1:dimP loop
         p[i].c=s1.c*kP[i]/kS1;
@@ -272,6 +264,14 @@ The reaction in the FastEquilibrium package is used to model reactions that are 
       s2.c=s1.c*kS2/kS1;
       s3.c=s1.c*kS3/kS1;
       s1.r + s2.r + s3.r + sum(p.r)=0;
+      annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     end Tmf;
 
-  end FastEquilibrium;
+    annotation(Diagram(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, grid={10,10})), Documentation(info="<html>
+<h1>FastEquilibrium</h1>
+The reaction in the FastEquilibrium package is used to model reactions that are very fast, and could be seen as an instant balance. These models are approximated to very fast reactions, if translated to SBML.
+<br>
+<img src=\"modelica://BioChem/Resources/Images/Fast.png\" >
+<br>
+</html>", revisions=""));
+end FastEquilibrium;

--- a/BioChem/Reactions/Hill/package.mo
+++ b/BioChem/Reactions/Hill/package.mo
@@ -1,22 +1,7 @@
 within BioChem.Reactions;
 package Hill "Hill reactions kinetics"
   extends Icons.Library;
-  annotation(Documentation(info="<html>
-<h1>Hill</h1>
- <p>
- This package contains models for Hill kinetics.
- </p>
-
-<br>
-<img src=\"modelica://BioChem/Resources/Images/Hill.png\" >
-<br>
- </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   model Hillr "Reversible Hill kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Reversible Hill kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uur;
     parameter Real h=1 "Hill Coefficient";
     parameter BioChem.Units.Concentration Keq=1 "Equilibrium constant";
@@ -25,14 +10,14 @@ package Hill "Hill reactions kinetics"
     parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
   equation
     rr=vF*s1.c/sHalf*(1 - p1.c/(s1.c*Keq))*(s1.c/sHalf + p1.c/pHalf)^(h - 1)/(1 + (s1.c/sHalf + p1.c/pHalf)^h);
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible Hill kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Hillr;
 
   model Hillmr "Reversible Hill kinetics with one modifier"
-    annotation(Documentation(info="<html>
- <p>
- Reversible Hill kinetics with one modifier.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uur;
     extends BioChem.Interfaces.Reactions.Modifiers.Modifier;
     parameter Real alfa=1 "Effect of s1 and p1 on binding of m";
@@ -49,14 +34,14 @@ package Hill "Hill reactions kinetics"
     K1=(s1.c/s1Half + p1.c/p1Half)^h;
     K2=(1 + (m1.c/m1Half)^h)/(1 + alfa*(m1.c/m1Half)^h);
     rr=vF*s1.c/s1Half*(1 - p1.c/(s1.c*Keq))*(s1.c/s1Half + p1.c/p1Half)^(h - 1)/(K1 + K2);
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible Hill kinetics with one modifier.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Hillmr;
 
   model Hillmmr "Reversible Hill kinetics with two modifiers"
-    annotation(Documentation(info="<html>
- <p>
- Reversible Hill kinetics with two modifiers.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uur;
     extends BioChem.Interfaces.Reactions.Modifiers.TwoModifiers;
     parameter Real alfa1=1 "Effect of s1 and p1 on binding of m";
@@ -76,20 +61,35 @@ package Hill "Hill reactions kinetics"
     K1=(s1.c/s1Half + p1.c/p1Half)^h;
     K2=(1 + (m1.c/m1Half)^h + (m2.c/m2Half)^h)/(1 + alfa1*(m1.c/m1Half)^h + alfa2*(m2.c/m2Half)^h + alfa12*(m1.c/m1Half)^h*(m2.c/m2Half)^h);
     rr=vF*s1.c/s1Half*(1 - p1.c/(s1.c*Keq))*(s1.c/s1Half + p1.c/p1Half)^(h - 1)/(K1 + K2);
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible Hill kinetics with two modifiers.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Hillmmr;
 
   model Hilli "Irreversible Hill kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible Hill kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     parameter Real h=1 "Hill Coefficient";
     parameter BioChem.Units.Concentration sHalf=1 "Substrate concentration such that v = vF/2";
     parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
   equation
     rr=vF*s1.c^h/(sHalf^h + s1.c^h);
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible Hill kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Hilli;
 
+  annotation(Documentation(info="<html>
+<h1>Hill</h1>
+ <p>
+ This package contains models for Hill kinetics.
+ </p>
+
+<br>
+<img src=\"modelica://BioChem/Resources/Images/Hill.png\" >
+<br>
+ </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end Hill;

--- a/BioChem/Reactions/HyperbolicModifier/package.mo
+++ b/BioChem/Reactions/HyperbolicModifier/package.mo
@@ -1,22 +1,7 @@
 within BioChem.Reactions;
 package HyperbolicModifier "Hyperbolic modifier kinetics reactions"
   extends Icons.Library;
-  annotation(Documentation(info="<html>
-<h1>HyperbolicModifier</h1>
- <p>
-This package contains models for irreversible and reversible hyperbolic modifier reaction kinetics.
- </p>
-<br>
-<img src=\"modelica://BioChem/Resources/Images/Hyper.png\" >
-<br>
-
- </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   model Uhmr "Reversible general hyperbolic modifier kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Reversible general hyperbolic modifier kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uur;
     extends BioChem.Interfaces.Reactions.Modifiers.Modifier;
     parameter Real a=1 "Ratio of dissociaton constants, ES+M->ESM over E+M->EM";
@@ -28,14 +13,14 @@ This package contains models for irreversible and reversible hyperbolic modifier
     parameter BioChem.Units.ReactionRate vR=1 "Reverse maximum velocity";
   equation
     rr=(vF*s1.c/KmS - vR*p1.c/KmP)*(1 + b*m1.c/(a*Kd))/(1 + m1.c/Kd + (s1.c/KmS + p1.c/KmP)*(1 + m1.c/(a*Kd)));
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible general hyperbolic modifier kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uhmr;
 
   model Uhmi "Irreversible general hyperbolic modifier kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible general hyperbolic modifier kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     extends BioChem.Interfaces.Reactions.Modifiers.Modifier;
     parameter Real a=1 "Ratio of dissociaton constants, ES+M->ESM over E+M->EM";
@@ -45,6 +30,21 @@ This package contains models for irreversible and reversible hyperbolic modifier
     parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
   equation
     rr=vF*s1.c/KmS*(1 + b*m1.c/(a*Kd))/(1 + m1.c/Kd + s1.c/KmS*(1 + m1.c/(a*Kd)));
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible general hyperbolic modifier kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uhmi;
 
+  annotation(Documentation(info="<html>
+<h1>HyperbolicModifier</h1>
+ <p>
+This package contains models for irreversible and reversible hyperbolic modifier reaction kinetics.
+ </p>
+<br>
+<img src=\"modelica://BioChem/Resources/Images/Hyper.png\" >
+<br>
+
+ </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end HyperbolicModifier;

--- a/BioChem/Reactions/Inhibition/package.mo
+++ b/BioChem/Reactions/Inhibition/package.mo
@@ -2,6 +2,183 @@ within BioChem.Reactions;
 
 package Inhibition "Inhibition kinetics reactions"
   extends Icons.Library;
+  model Uucr "Uncompetitive inhibition (reversible)"
+    extends BioChem.Interfaces.Reactions.Uur;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Ki=1 "Inhibition constant for the substrate";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter Real KmP=1 "Reverse Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+    parameter BioChem.Units.ReactionRate vR=1 "Reverese maximum velocity";
+  equation
+    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + (s1.c/KmS + p1.c/KmP)*(1 + i1.c/Ki));
+    annotation(Documentation(info="<html>
+ <p>
+ Uncompetitive inhibition (reversible).
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Uucr;
+
+  model Uuci "Irreversible uncompetitive inhibition"
+    extends BioChem.Interfaces.Reactions.Uui;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Ki=1 "Inhibition constant for the substrate";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF*s1.c/KmS/(1 + s1.c/KmS*(1 + i1.c/Ki));
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible uncompetitive inhibition.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Uuci;
+
+  model Usir "Reversible substrate inhibition kinetics"
+    extends BioChem.Interfaces.Reactions.Uui;
+    parameter BioChem.Units.Concentration Ki=1 "Inhibition constant for the substrate";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter Real KmP=1 "Reverese Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+    parameter BioChem.Units.ReactionRate vR=1 "Reversible maximum velocity";
+  equation
+    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + s1.c/KmS + p1.c/KmP + s1.c^2/Ki);
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible substrate inhibition kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Usir;
+
+  model Usii "Irreversible substrate inhibition kinetics"
+    extends BioChem.Interfaces.Reactions.Uui;
+    parameter BioChem.Units.Concentration Ki=1 "Inhibition constant for the substrate";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF*s1.c/KmS/(1 + s1.c/KmS + s1.c^2/Ki);
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible substrate inhibition kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Usii;
+
+  model Unir "Noncompetitive inhibition (reversible)"
+    extends BioChem.Interfaces.Reactions.Uur;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Ki=1 "Inhibition constant for the substrate";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter Real KmP=1 "Reverse Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+    parameter BioChem.Units.ReactionRate vR=1 "Reverese maximum velocity";
+  equation
+    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + i1.c/Ki + (s1.c/KmS + p1.c/KmP)*(1 + i1.c/Ki));
+    annotation(Documentation(info="<html>
+ <p>
+ Noncompetitive inhibition (reversible).
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Unir;
+
+  model Unii "Irreversible non-competitive inhibition kinetics"
+    extends BioChem.Interfaces.Reactions.Uui;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Ki=1 "Inhibition constant for the substrate";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF*s1.c/KmS/(1 + i1.c/Ki + s1.c/KmS*(1 + i1.c/Ki));
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible non-competitive inhibition kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Unii;
+
+  model Umr "Reversible mixed inhibition kinetics"
+    extends BioChem.Interfaces.Reactions.Uur;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Kis=1 "Specific (competitive) inhibition constant";
+    parameter Real Kic=1 "Catalytic (non-competitive) inhibition constant";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter Real KmP=1 "Reverse Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+    parameter BioChem.Units.ReactionRate vR=1 "Reverese maximum velocity";
+  equation
+    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + i1.c/Kis + (s1.c/KmS + p1.c/KmP)*(1 + i1.c/Kic));
+    annotation(Documentation(info="<html>
+ <p>
+ Reversible mixed inhibition kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Umr;
+
+  model Umi "Irreversible mixed inhibition kinetics"
+    extends BioChem.Interfaces.Reactions.Uui;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Kic=1 "Catalytic inhibition constant";
+    parameter Real Kis=1 "Specific inhibition constant";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF*s1.c/KmS/(1 + i1.c/Kis + s1.c/KmS*(1 + i1.c/Kic));
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible mixed inhibition kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Umi;
+
+  model Ucir "Competitive inhibition (reversible)"
+    extends BioChem.Interfaces.Reactions.Uur;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Ki=1 "Inhibition constant for the substrate";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter Real KmP=1 "Reverse Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+    parameter BioChem.Units.ReactionRate vR=1 "Reverese maximum velocity";
+  equation
+    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + s1.c/KmS + p1.c/KmP + i1.c/Ki);
+    annotation(Documentation(info="<html>
+ <p>
+ Competitive inhibition (reversible).
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Ucir;
+
+  model Ucii "Irreversible competitive inhibition kinetics"
+    extends BioChem.Interfaces.Reactions.Uui;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Ki=1 "Inhibition constant for the substrate";
+    parameter Real KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF*s1.c/KmS/(1 + s1.c/KmS + i1.c/Ki);
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible competitive inhibition kinetics.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Ucii;
+
+  model Ualii "Irreversible allosteric inhibition"
+    extends BioChem.Interfaces.Reactions.Uui;
+    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
+    parameter Real Kii=1 "Dissociation constant of the inhibitor from the inactive form of the enzyme";
+    parameter Real Ks=1 "Dissociation constant of the substrate from the active form of the enzyme";
+    parameter Real L=1 "Equibrilium constant between active and inactive enzyme";
+    parameter Integer n=1 "Number of binding sites for substrate and inhibitor";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF*s1.c/Ks*(1 + s1.c/Ks)^(n - 1)/(L*(1 + i1.c/Kii)^n + (1 + s1.c/Ks)^n);
+    annotation(Documentation(info="<html>
+ <p>
+ Irreversible allosteric inhibition.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Ualii;
+
   annotation(Documentation(info="<html>
 <h1>Inhibition</h1>
  <p>
@@ -15,181 +192,4 @@ In this package, different types of irreversible and reversible inhibition react
 
 
  </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-  model Uucr "Uncompetitive inhibition (reversible)"
-    annotation(Documentation(info="<html>
- <p>
- Uncompetitive inhibition (reversible).
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uur;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Ki=1 "Inhibition constant for the substrate";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter Real KmP=1 "Reverse Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-    parameter BioChem.Units.ReactionRate vR=1 "Reverese maximum velocity";
-  equation
-    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + (s1.c/KmS + p1.c/KmP)*(1 + i1.c/Ki));
-  end Uucr;
-
-  model Uuci "Irreversible uncompetitive inhibition"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible uncompetitive inhibition.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uui;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Ki=1 "Inhibition constant for the substrate";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF*s1.c/KmS/(1 + s1.c/KmS*(1 + i1.c/Ki));
-  end Uuci;
-
-  model Usir "Reversible substrate inhibition kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Reversible substrate inhibition kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uui;
-    parameter BioChem.Units.Concentration Ki=1 "Inhibition constant for the substrate";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter Real KmP=1 "Reverese Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-    parameter BioChem.Units.ReactionRate vR=1 "Reversible maximum velocity";
-  equation
-    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + s1.c/KmS + p1.c/KmP + s1.c^2/Ki);
-  end Usir;
-
-  model Usii "Irreversible substrate inhibition kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible substrate inhibition kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uui;
-    parameter BioChem.Units.Concentration Ki=1 "Inhibition constant for the substrate";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF*s1.c/KmS/(1 + s1.c/KmS + s1.c^2/Ki);
-  end Usii;
-
-  model Unir "Noncompetitive inhibition (reversible)"
-    annotation(Documentation(info="<html>
- <p>
- Noncompetitive inhibition (reversible).
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uur;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Ki=1 "Inhibition constant for the substrate";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter Real KmP=1 "Reverse Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-    parameter BioChem.Units.ReactionRate vR=1 "Reverese maximum velocity";
-  equation
-    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + i1.c/Ki + (s1.c/KmS + p1.c/KmP)*(1 + i1.c/Ki));
-  end Unir;
-
-  model Unii "Irreversible non-competitive inhibition kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible non-competitive inhibition kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uui;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Ki=1 "Inhibition constant for the substrate";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF*s1.c/KmS/(1 + i1.c/Ki + s1.c/KmS*(1 + i1.c/Ki));
-  end Unii;
-
-  model Umr "Reversible mixed inhibition kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Reversible mixed inhibition kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uur;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Kis=1 "Specific (competitive) inhibition constant";
-    parameter Real Kic=1 "Catalytic (non-competitive) inhibition constant";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter Real KmP=1 "Reverse Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-    parameter BioChem.Units.ReactionRate vR=1 "Reverese maximum velocity";
-  equation
-    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + i1.c/Kis + (s1.c/KmS + p1.c/KmP)*(1 + i1.c/Kic));
-  end Umr;
-
-  model Umi "Irreversible mixed inhibition kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible mixed inhibition kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uui;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Kic=1 "Catalytic inhibition constant";
-    parameter Real Kis=1 "Specific inhibition constant";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF*s1.c/KmS/(1 + i1.c/Kis + s1.c/KmS*(1 + i1.c/Kic));
-  end Umi;
-
-  model Ucir "Competitive inhibition (reversible)"
-    annotation(Documentation(info="<html>
- <p>
- Competitive inhibition (reversible).
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uur;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Ki=1 "Inhibition constant for the substrate";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter Real KmP=1 "Reverse Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-    parameter BioChem.Units.ReactionRate vR=1 "Reverese maximum velocity";
-  equation
-    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + s1.c/KmS + p1.c/KmP + i1.c/Ki);
-  end Ucir;
-
-  model Ucii "Irreversible competitive inhibition kinetics"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible competitive inhibition kinetics.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uui;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Ki=1 "Inhibition constant for the substrate";
-    parameter Real KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF*s1.c/KmS/(1 + s1.c/KmS + i1.c/Ki);
-  end Ucii;
-
-  model Ualii "Irreversible allosteric inhibition"
-    annotation(Documentation(info="<html>
- <p>
- Irreversible allosteric inhibition.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uui;
-    extends BioChem.Interfaces.Reactions.Modifiers.Inhibitor;
-    parameter Real Kii=1 "Dissociation constant of the inhibitor from the inactive form of the enzyme";
-    parameter Real Ks=1 "Dissociation constant of the substrate from the active form of the enzyme";
-    parameter Real L=1 "Equibrilium constant between active and inactive enzyme";
-    parameter Integer n=1 "Number of binding sites for substrate and inhibitor";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF*s1.c/Ks*(1 + s1.c/Ks)^(n - 1)/(L*(1 + i1.c/Kii)^n + (1 + s1.c/Ks)^n);
-  end Ualii;
-
 end Inhibition;

--- a/BioChem/Reactions/MassAction/Irreversible/UniUni/package.mo
+++ b/BioChem/Reactions/MassAction/Irreversible/UniUni/package.mo
@@ -2,43 +2,43 @@ within BioChem.Reactions.MassAction.Irreversible;
 
 package UniUni "A -> B reactions"
   extends Icons.Library;
-  annotation(Documentation(info="<html>
-<p>This package contains models for stoichiometric reactions with one reactant and one product.</p>
-</html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   model Uuifi "Uni-uni irrerversible forward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
   equation
     rr=k1/iF1.c*s1.c^nS1*s1.V;
+    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uuifi;
 
   model Uuifafi "Uni-uni irrerversible forward activation, forward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c/iF1.c*s1.c^nS1*s1.V;
+    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uuifafi;
 
   model Uuifa "Uni-uni irrerversible forward activation reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c*s1.c^nS1*s1.V;
+    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uuifa;
 
   model Uui "Uni-uni irrerversible reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Uui;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
   equation
     rr=k1*s1.c^nS1*s1.V;
+    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Uui;
 
+  annotation(Documentation(info="<html>
+<p>This package contains models for stoichiometric reactions with one reactant and one product.</p>
+</html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end UniUni;

--- a/BioChem/Reactions/MassAction/Reversible/BiTri/package.mo
+++ b/BioChem/Reactions/MassAction/Reversible/BiTri/package.mo
@@ -2,11 +2,7 @@ within BioChem.Reactions.MassAction.Reversible;
 
 package BiTri "A+B <-> C+D+E reactions"
   extends Icons.Library;
-  annotation(Documentation(info="<html>
-<p>This package contains models for stoichiometric reactions with two reactants and three products.</p>
-</html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   model Btrfibi "Bi-tri reversible forward inhibition, backward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorBackward;
@@ -14,10 +10,10 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1/iF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2/iB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfibi;
 
   model Btrfibabi "Bi-tri reversible forward inhibition, backward activation, backward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorBackward;
@@ -26,10 +22,10 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1/iF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*aB1.c/iB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfibabi;
 
   model Btrfiba "Bi-tri reversible forward inhibition, backward activation reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorBackward;
@@ -37,20 +33,20 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1/iF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*aB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfiba;
 
   model Btrfi "Bi-tri reversible forward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1/iF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfi;
 
   model Btrfafibi "Bi-tri reversible forward activation, forward inhibition, backward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
@@ -59,10 +55,10 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c/iF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2/iB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfafibi;
 
   model Btrfafibabi "Bi-tri reversible forward activation, forward inhibition, backward activation, backward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
@@ -72,10 +68,10 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c/iF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*aB1.c/iB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfafibabi;
 
   model Btrfafiba "Bi-tri reversible forward activation, forward inhibition, backward activation reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
@@ -84,10 +80,10 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c/iF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*aB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfafiba;
 
   model Btrfafi "Bi-tri reversible forward activation, forward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorForward;
@@ -95,10 +91,10 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c/iF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfafi;
 
   model Btrfabi "Bi-tri reversible forward activation, backward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorBackward;
@@ -106,10 +102,10 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2/iB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfabi;
 
   model Btrfababi "Bi-tri reversible forward activation, backward activation, backward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorBackward;
@@ -118,10 +114,10 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*aB1.c/iB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfababi;
 
   model Btrfaba "Bi-tri reversible forward activation, backward activation reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorBackward;
@@ -129,30 +125,30 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*aB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfaba;
 
   model Btrfa "Bi-tri reversible forward activation reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorForward;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*aF1.c*s1.c^nS1*s2.c^nS2*s1.V - k2*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrfa;
 
   model Btrbi "Bi-tri reversible backward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorBackward;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*s1.c^nS1*s2.c^nS2*s1.V - k2/iB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrbi;
 
   model Btrbabi "Bi-tri reversible backward activation, backward inhibition reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorBackward;
     extends BioChem.Interfaces.Reactions.Modifiers.InhibitorBackward;
@@ -160,25 +156,29 @@ package BiTri "A+B <-> C+D+E reactions"
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*s1.c^nS1*s2.c^nS2*s1.V - k2*aB1.c/iB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrbabi;
 
   model Btrba "Bi-tri reversible backward activation reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     extends BioChem.Interfaces.Reactions.Modifiers.ActivatorBackward;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*s1.c^nS1*s2.c^nS2*s1.V - k2*aB1.c*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btrba;
 
   model Btr "Bi-tri reversible reaction"
-    annotation(Documentation(), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
     extends BioChem.Interfaces.Reactions.Btr;
     parameter BioChem.Units.ReactionCoefficient k1=1 "Forwards reaction coefficient for the reaction";
     parameter BioChem.Units.ReactionCoefficient k2=1 "Backwards reaction coefficient for the reaction";
   equation
     rr=k1*s1.c^nS1*s2.c^nS2*s1.V - k2*p1.c^nP1*p2.c^nP2*p3.c^nP3*p1.V;
+    annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   end Btr;
 
+  annotation(Documentation(info="<html>
+<p>This package contains models for stoichiometric reactions with two reactants and three products.</p>
+</html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end BiTri;

--- a/BioChem/Reactions/MichaelisMenten/package.mo
+++ b/BioChem/Reactions/MichaelisMenten/package.mo
@@ -1,6 +1,65 @@
 within BioChem.Reactions;
 package MichaelisMenten "Michaelis-Menten kinetics reactions"
   extends Icons.Library;
+  model Uur "Uni-uni reversible simple Michaelis-Menten"
+    extends BioChem.Interfaces.Reactions.Uur;
+    parameter BioChem.Units.Concentration KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.Concentration KmP=1 "Reverse Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+    parameter BioChem.Units.ReactionRate vR=1 "Reverse maximum velocity";
+  equation
+    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + s1.c/KmS + p1.c/KmP);
+    annotation(Documentation(info="<html>
+ <p>
+ Uni-uni reversible simple Michaelis-Menten.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Uur;
+
+  model Uui "Uni-uni irreversible simple Michaelis-Menten"
+    extends BioChem.Interfaces.Reactions.Uui;
+    parameter BioChem.Units.Concentration KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF*s1.c/(KmS + s1.c);
+    annotation(Documentation(info="<html>
+ <p>
+ Uni-uni irreversible simple Michaelis-Menten.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Uui;
+
+  model Uuhr "Uni-Uni reversible simple Michaelis-Menten with Haldane adjustment"
+    extends BioChem.Interfaces.Reactions.Uur;
+    parameter Real Keq=1 "Equilibrum constant";
+    parameter BioChem.Units.Concentration KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.Concentration KmP=1 "Reverse Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF/KmS*(s1.c - p1.c/Keq)/(1 + s1.c/KmS + p1.c/KmP);
+    annotation(Documentation(info="<html>
+ <p>
+ Uni-Uni reversible simple Michaelis-Menten with Haldane adjustment.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Uuhr;
+
+  model Isouur "Iso uni-uni"
+    extends BioChem.Interfaces.Reactions.Uur;
+    parameter Real Keq=1 "Equilibrum constant";
+    parameter Real Kii=1 "Isoinhibition constant";
+    parameter BioChem.Units.Concentration KmS=1 "Forward Michaelis-Menten constant";
+    parameter BioChem.Units.Concentration KmP=1 "Reverse Michaelis-Menten constant";
+    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
+  equation
+    rr=vF*(s1.c - p1.c/Keq)/(s1.c*(1 + p1.c/Kii) + KmS*(1 + p1.c/KmP));
+    annotation(Documentation(info="<html>
+ <p>
+ Iso uni-uni.
+ </p>
+ </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  end Isouur;
+
   annotation(Documentation(info="<html>
 <h1>MichaelisMenten</h1>
  <p>
@@ -14,63 +73,4 @@ Michaelis-Menten kinetics describes the kinetics of many enzymes. It is named af
 
 
  </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-  model Uur "Uni-uni reversible simple Michaelis-Menten"
-    annotation(Documentation(info="<html>
- <p>
- Uni-uni reversible simple Michaelis-Menten.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uur;
-    parameter BioChem.Units.Concentration KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.Concentration KmP=1 "Reverse Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-    parameter BioChem.Units.ReactionRate vR=1 "Reverse maximum velocity";
-  equation
-    rr=(vF*s1.c/KmS - vR*p1.c/KmP)/(1 + s1.c/KmS + p1.c/KmP);
-  end Uur;
-
-  model Uui "Uni-uni irreversible simple Michaelis-Menten"
-    annotation(Documentation(info="<html>
- <p>
- Uni-uni irreversible simple Michaelis-Menten.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uui;
-    parameter BioChem.Units.Concentration KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF*s1.c/(KmS + s1.c);
-  end Uui;
-
-  model Uuhr "Uni-Uni reversible simple Michaelis-Menten with Haldane adjustment"
-    annotation(Documentation(info="<html>
- <p>
- Uni-Uni reversible simple Michaelis-Menten with Haldane adjustment.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uur;
-    parameter Real Keq=1 "Equilibrum constant";
-    parameter BioChem.Units.Concentration KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.Concentration KmP=1 "Reverse Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF/KmS*(s1.c - p1.c/Keq)/(1 + s1.c/KmS + p1.c/KmP);
-  end Uuhr;
-
-  model Isouur "Iso uni-uni"
-    annotation(Documentation(info="<html>
- <p>
- Iso uni-uni.
- </p>
- </html>"), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-    extends BioChem.Interfaces.Reactions.Uur;
-    parameter Real Keq=1 "Equilibrum constant";
-    parameter Real Kii=1 "Isoinhibition constant";
-    parameter BioChem.Units.Concentration KmS=1 "Forward Michaelis-Menten constant";
-    parameter BioChem.Units.Concentration KmP=1 "Reverse Michaelis-Menten constant";
-    parameter BioChem.Units.ReactionRate vF=1 "Forward maximum velocity";
-  equation
-    rr=vF*(s1.c - p1.c/Keq)/(s1.c*(1 + p1.c/Kii) + KmS*(1 + p1.c/KmP));
-  end Isouur;
-
 end MichaelisMenten;

--- a/BioChem/Substances/Substance.mo
+++ b/BioChem/Substances/Substance.mo
@@ -1,12 +1,12 @@
 within BioChem.Substances;
 
 model Substance "Substance with variable concentration"
+  extends BioChem.Interfaces.Substances.Substance;
+equation
+  der(n)=rNet;
   annotation(Documentation(info="<html>
 <p>
 A substance with variable concentration.
 </p>
 </html>"), Icon(coordinateSystem(extent={{-100,-100},{100,100}}, preserveAspectRatio=true, grid={10,10}), graphics={Text(origin={7.10543e-15,50}, fillPattern=FillPattern.Solid, extent={{-100,-150},{100,-100}}, textString="%name", fontName="Arial"),Ellipse(lineColor={0,85,0}, fillColor={0,170,0}, fillPattern=FillPattern.Sphere, extent={{-50,-50},{50,50}})}), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
-  extends BioChem.Interfaces.Substances.Substance;
-equation
-  der(n)=rNet;
 end Substance;

--- a/BioChem/Units/package.mo
+++ b/BioChem/Units/package.mo
@@ -1,12 +1,6 @@
 within BioChem;
 package Units "Units used in BioChem"
   extends Icons.Library;
-  annotation(Documentation(info="<html>
-<h1>Units</h1>
- <p>
- This pace contains definitions of units that are common in biochemical models.
- </p>
- </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Text(origin={0,-13.3333}, fillPattern=FillPattern.Solid, extent={{-100,-86.6667},{73.34,43.3333}}, textString="C", fontName="Arial"),Text(origin={0,-10}, fillPattern=FillPattern.Solid, extent={{6.51,6.81},{50,53.19}}, textString="o", fontName="Arial")}), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   type VolumetricReactionRate= Real(quantity="Volumetric reaction rate", unit="mol/(s.l)") annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   type VolumeChangeConstant= Real(quantity="Volume change constant", unit="l/s") annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   type Volume= Modelica.SIunits.Conversions.NonSIunits.Volume_litre annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
@@ -21,4 +15,10 @@ package Units "Units used in BioChem"
   type Celcius= Modelica.SIunits.Conversions.NonSIunits.Temperature_degC annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   type AmountOfSubstance= Real(quantity="AmountOfSubstance", unit="mol", min=0) annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
   type EquilibriumCoefficient= Real(quantity="Equilibrium coefficient", unit="1") "" annotation(Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
+  annotation(Documentation(info="<html>
+<h1>Units</h1>
+ <p>
+ This pace contains definitions of units that are common in biochemical models.
+ </p>
+ </html>", revisions=""), Icon(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10}), graphics={Text(origin={0,-13.3333}, fillPattern=FillPattern.Solid, extent={{-100,-86.6667},{73.34,43.3333}}, textString="C", fontName="Arial"),Text(origin={0,-10}, fillPattern=FillPattern.Solid, extent={{6.51,6.81},{50,53.19}}, textString="o", fontName="Arial")}), Diagram(coordinateSystem(extent={{-100,100},{100,-100}}, preserveAspectRatio=true, grid={10,10})));
 end Units;


### PR DESCRIPTION
The Modelica grammar does not allow annotations except at the end of a class.

This prepares the package for using the conversion script and is related to #17.